### PR TITLE
Fix WMO Res. 40 link

### DIFF
--- a/src/sources.md
+++ b/src/sources.md
@@ -11,4 +11,4 @@ Meteostat uses weather and climate data provided by the following interfaces and
 * [European Data Portal](https://www.europeandataportal.eu/en)
 * [Offene Daten Österreich](https://www.data.gv.at/) ([License](https://creativecommons.org/licenses/by/3.0/at/deed.en))
 
-The interfaces and databases used by Meteostat provide weather and climate data with global coverage. The data is gathered by different members of the World Meteorological Organization (WMO) and is being shared under the terms of [WMO resolution 40](https://www.wmo.int/pages/prog/www/ois/Operational_Information/Publications/Congress/Cg_XII/res40_en.html).
+The interfaces and databases used by Meteostat provide weather and climate data with global coverage. The data is gathered by different members of the World Meteorological Organization (WMO) and is being shared under the terms of [WMO resolution 40](https://community.wmo.int/resolution-40).


### PR DESCRIPTION
Link to WMO res 40 is 404 on the sources page.

The link on the terms page works. Updated the the link on the source page to the one from the terms page.